### PR TITLE
Use a cached DNS resolver for the UPD host

### DIFF
--- a/lib/statix/cached_resolver.ex
+++ b/lib/statix/cached_resolver.ex
@@ -1,0 +1,52 @@
+defmodule Statix.CachedResolver do
+  @moduledoc """
+  A module that provides a cached DNS resolver.
+  """
+  @table_name :statix_host_cache
+  @resolve_cache_interval 15_000
+
+  @spec init() :: :ok
+  def init do
+    :ets.new(@table_name, [:set, :public, :named_table])
+    :ok
+  end
+
+  @spec get_or_resolve_ip(:inet.ip_address() | :inet.hostname()) ::
+          :inet.ip_address() | no_return()
+  def get_or_resolve_ip(address) when is_tuple(address), do: address
+
+  def get_or_resolve_ip(host) do
+    :ets.lookup(:statix_host_cache, host)
+    |> case do
+      [{_, address, expiration}] ->
+        if expiration < System.monotonic_time(:millisecond) do
+          true = :ets.delete(:statix_host_cache, host)
+          resolve_and_cache(host)
+        else
+          address
+        end
+
+      _ ->
+        resolve_and_cache(host)
+    end
+  end
+
+  defp resolve_and_cache(host) do
+    case :inet.getaddr(to_charlist(host), :inet) do
+      {:ok, address} ->
+        true =
+          :ets.insert(
+            :statix_host_cache,
+            {host, address, System.monotonic_time(:millisecond) + @resolve_cache_interval}
+          )
+
+        address
+
+      {:error, reason} ->
+        raise(
+          "cannot get the IP address for the provided host " <>
+            "due to reason: #{:inet.format_error(reason)}"
+        )
+    end
+  end
+end

--- a/lib/statix/conn.ex
+++ b/lib/statix/conn.ex
@@ -3,28 +3,23 @@ defmodule Statix.Conn do
 
   defstruct [:sock, :address, :port, :prefix]
 
+  alias Statix.CachedResolver
   alias Statix.Packet
 
   require Logger
 
-  otp_release = :erlang.system_info(:otp_release)
-  @otp_gte_26 otp_release >= ~c"26"
-
+  @spec new(
+          host :: :inet.hostname() | :inet.ip_address(),
+          port :: :inet.port_number(),
+          prefix :: String.t()
+        ) :: %__MODULE__{}
   def new(host, port, prefix) when is_binary(host) do
     new(String.to_charlist(host), port, prefix)
   end
 
   def new(host, port, prefix) when is_list(host) or is_tuple(host) do
-    case :inet.getaddr(host, :inet) do
-      {:ok, address} ->
-        %__MODULE__{address: address, port: port, prefix: prefix}
-
-      {:error, reason} ->
-        raise(
-          "cannot get the IP address for the provided host " <>
-            "due to reason: #{:inet.format_error(reason)}"
-        )
-    end
+    CachedResolver.init()
+    %__MODULE__{address: host, port: port, prefix: prefix}
   end
 
   def open(%__MODULE__{} = conn) do
@@ -53,30 +48,10 @@ defmodule Statix.Conn do
   defp transmit(packet, %__MODULE__{address: address, port: port, sock: sock_name}) do
     sock = Process.whereis(sock_name)
 
-    # The check below was implemented for backwards compatibility to avoid a performance issue on
-    # OTP on versiones older than 26. If the OTP version is 26 or above, we use gen_udp.send/4. If
-    # the version is older than that, we use the existing performance issue workaround.
-    if @otp_gte_26 do
-      if sock do
-        :gen_udp.send(sock, address, port, packet)
-      else
-        {:error, :port_closed}
-      end
+    if sock do
+      :gen_udp.send(sock, CachedResolver.get_or_resolve_ip(address), port, packet)
     else
-      # This branch will only be executed on older version of OTP and will be eventually removed.
-      packet_with_header = Packet.add_header(packet, address, port)
-
-      try do
-        Port.command(sock, packet_with_header)
-      rescue
-        ArgumentError ->
-          {:error, :port_closed}
-      else
-        true ->
-          receive do
-            {:inet_reply, _port, status} -> status
-          end
-      end
+      {:error, :port_closed}
     end
   end
 end

--- a/test/statix/cached_resolver_test.exs
+++ b/test/statix/cached_resolver_test.exs
@@ -1,0 +1,52 @@
+defmodule Statix.CachedResolverTest do
+  use ExUnit.Case, async: false
+
+  alias Statix.CachedResolver
+
+  setup_all do
+    :ok = CachedResolver.init()
+  end
+
+  describe "get_or_resolve_ip/1" do
+    setup do
+      # ensure the cache is empty before each test to avoid interference between tests
+      :ets.delete_all_objects(:statix_host_cache)
+
+      :ok
+    end
+
+    test "returns the IP address for a given hostname" do
+      assert CachedResolver.get_or_resolve_ip("localhost") == {127, 0, 0, 1}
+      assert CachedResolver.get_or_resolve_ip(~c"localhost") == {127, 0, 0, 1}
+    end
+
+    test "caches the value after resolving a hostname" do
+      assert CachedResolver.get_or_resolve_ip("localhost") == {127, 0, 0, 1}
+      assert [{"localhost", {127, 0, 0, 1}, _ttl}] = :ets.lookup(:statix_host_cache, "localhost")
+    end
+
+    test "uses the cached value for a given hostname" do
+      :ets.insert(:statix_host_cache, {"some.test.host", {127, 0, 0, 5}, 1000})
+      assert CachedResolver.get_or_resolve_ip("some.test.host") == {127, 0, 0, 5}
+    end
+
+    test "evicts the cache entry after a certain time" do
+      ttl = System.monotonic_time(:millisecond) - 30
+      :ets.insert(:statix_host_cache, {"localhost", {127, 0, 0, 2}, ttl})
+      assert CachedResolver.get_or_resolve_ip("localhost") == {127, 0, 0, 1}
+
+      assert [{"localhost", {127, 0, 0, 1}, new_ttl}] =
+               :ets.lookup(:statix_host_cache, "localhost")
+
+      assert new_ttl > ttl
+    end
+
+    test "returns the IP address for a given IP address" do
+      assert CachedResolver.get_or_resolve_ip({127, 0, 0, 1}) == {127, 0, 0, 1}
+    end
+
+    test "raises an error for an invalid hostname" do
+      assert_raise RuntimeError, fn -> CachedResolver.get_or_resolve_ip("invalid.host.name") end
+    end
+  end
+end


### PR DESCRIPTION
Currently, the DNS resolution for the statsd socket happens only on application start. Since we have datadog-agents moving around pods, we need to dynamically resolve the IP before sending packets. This implementation uses a cached resolver to avoid hitting CoreDNS all the time.